### PR TITLE
another approach to requesting consumed capacity to save calls

### DIFF
--- a/lib/aws-record/record/item_operations.rb
+++ b/lib/aws-record/record/item_operations.rb
@@ -107,20 +107,14 @@ module Aws
       end
 
       def _perform_save(opts)
-        force = opts[:force]
-        expect_new = expect_new_item?
-        if force
-          dynamodb_client.put_item(
-            table_name: self.class.table_name,
-            item: _build_item_for_save
-          )
-        elsif expect_new
-          put_opts = {
-            table_name: self.class.table_name,
-            item: _build_item_for_save
-          }.merge(prevent_overwrite_expression)
+        request_opts = opts.except(:force).merge(table_name: self.class.table_name)
+        if opts[:force]
+          dynamodb_client.put_item(request_opts.merge(item: _build_item_for_save))
+        elsif expect_new_item?
+          request_opts.merge!(item: _build_item_for_save)
+          request_opts.merge!(prevent_overwrite_expression)
           begin
-            dynamodb_client.put_item(put_opts)
+            dynamodb_client.put_item(request_opts)
           rescue Aws::DynamoDB::Errors::ConditionalCheckFailedException => e
             raise Errors::ConditionalWriteFailed.new(
               "Conditional #put_item call failed! Check that conditional write"\
@@ -129,27 +123,20 @@ module Aws
             )
           end
         else
-          update_pairs = _dirty_changes_for_update
+          request_opts.merge!(key: key_values)
           update_tuple = self.class.send(
             :_build_update_expression,
-            update_pairs
+            _dirty_changes_for_update
           )
           if update_tuple
             uex, exp_attr_names, exp_attr_values = update_tuple
-            request_opts = {
-              table_name: self.class.table_name,
-              key: key_values,
+            request_opts.merge!({
               update_expression: uex,
               expression_attribute_names: exp_attr_names,
-            }
+            })
             request_opts[:expression_attribute_values] = exp_attr_values unless exp_attr_values.empty?
-            dynamodb_client.update_item(request_opts)
-          else
-            dynamodb_client.update_item(
-              table_name: self.class.table_name,
-              key: key_values
-            )
           end
+          dynamodb_client.update_item(request_opts)
         end
       end
 

--- a/spec/aws-record/record/item_operations_spec.rb
+++ b/spec/aws-record/record/item_operations_spec.rb
@@ -167,6 +167,32 @@ module Aws
           }])
         end
 
+        it 'will pass the return_consumed_capacity argument to the dynamo update' do
+          klass.configure_client(client: stub_client)
+          item = klass.new
+          item.id = 1
+          item.date = '2015-12-14'
+          item.body = 'Hello!'
+          item.clean! # I'm claiming that it is this way in the DB now.
+          item.body = 'Goodbye!'
+          item.save(return_consumed_capacity: "TOTAL")
+          expect(api_requests).to eq([{
+            table_name: "TestTable",
+            key: {
+              "id" => { n: "1" },
+              "MyDate" => { s: "2015-12-14" }
+            },
+            update_expression: "SET #UE_A = :ue_a",
+            expression_attribute_names: {
+              "#UE_A" => "body"
+            },
+            expression_attribute_values: {
+              ":ue_a" => { s: "Goodbye!" }
+            },
+            return_consumed_capacity: "TOTAL"
+          }])
+        end
+
         it 'raises an exception when the conditional check fails' do
           stub_client.stub_responses(:put_item,
             'ConditionalCheckFailedException'


### PR DESCRIPTION
I want to be able to see how much write capacity individual saves are consuming. At the moment I think it's not possible. This PR fixes that by passing any options supplied to a `save` call through to the eventual Dynamo call. Supplying `return_consumed_capacity: "TOTAL"` means the result returned by the save call will show the consumed write capacity.

Here's what it looks like:

```ruby
> u.save return_consumed_capacity: "TOTAL"

[Aws::DynamoDB::Client 200 0.024123 0 retries] update_item(table_name:"some_table",key:{"id"=>{s:"4e95893384d7ec000300c62b"}},return_consumed_capacity:"TOTAL")

=> #<struct Aws::DynamoDB::Types::UpdateItemOutput
 attributes=nil,
 consumed_capacity=
  #<struct Aws::DynamoDB::Types::ConsumedCapacity
   table_name="some_table",
   capacity_units=10.0,
   table=nil,
   local_secondary_indexes=nil,
   global_secondary_indexes=nil>,
 item_collection_metrics=nil>
```

I tries another approach in #60 but I prefer this approach because:

* it allows for any other options to be passed through to the dynamo call
* it DRYs up the `request_opts` - ensuring that all dynamo operations use the same base options hash
* it makes some simplifications to the `_perform_save` method
