### PR TITLE
Add attribute_names class/instnace methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - add `attribute_names` class/instance method. (#145)
+
 2.13.2 (2024-08-21)
 ------------------
 

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -77,6 +77,11 @@ module Aws
         @data.hash_copy
       end
 
+      # @return [Array] List of attribute names.
+      def attribute_names
+        self.class.attribute_names
+      end
+
       def self.inherit_attributes(klass)
         superclass_attributes = klass.superclass.instance_variable_get('@attributes')
 
@@ -514,6 +519,11 @@ module Aws
         # @api private
         def attributes
           @attributes
+        end
+
+        # @return [Array] List of attribute names.
+        def attribute_names
+          @attributes.attributes.keys
         end
 
         # @api private

--- a/spec/aws-record/record_spec.rb
+++ b/spec/aws-record/record_spec.rb
@@ -143,6 +143,29 @@ module Aws
       end
     end
 
+    describe 'attribute_names' do
+      let(:model) do
+        Class.new do
+          include(Aws::Record)
+          set_table_name('TestTable')
+          string_attr(:uuid, hash_key: true)
+          string_attr(:other_attr)
+        end
+      end
+
+      describe '.attribute_names' do
+        it 'returns the attribute names' do
+          expect(model.attribute_names).to eq(%i[uuid other_attr])
+        end
+      end
+
+      describe '#attribute_names' do
+        it 'returns the attribute names' do
+          expect(model.new.attribute_names).to eq(%i[uuid other_attr])
+        end
+      end
+    end
+
     describe 'inheritance support for table name' do
       let(:parent_model) do
         Class.new do


### PR DESCRIPTION
*Issue #, if available:*'
Fixes #145 

*Description of changes:*
Adds `attribute_names` class/instance methods inline with ActiveRecord's [attribute_names](https://apidock.com/rails/ActiveRecord/AttributeMethods/ClassMethods/attribute_names) method(s).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
