### PR TITLE
Update Batch.read to accept a client parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Use configured clients for batch reads in `find_all`.
+
 2.13.3 (2025-01-02)
 ------------------
 

--- a/lib/aws-record/record/item_operations.rb
+++ b/lib/aws-record/record/item_operations.rb
@@ -631,8 +631,8 @@ module Aws
             end
           end
           update_expressions = []
-          update_expressions << ("SET #{set_expressions.join(', ')}") unless set_expressions.empty?
-          update_expressions << ("REMOVE #{remove_expressions.join(', ')}") unless remove_expressions.empty?
+          update_expressions << "SET #{set_expressions.join(', ')}" unless set_expressions.empty?
+          update_expressions << "REMOVE #{remove_expressions.join(', ')}" unless remove_expressions.empty?
           {
             update_expression: update_expressions.join(' '),
             expression_attribute_names: exp_attr_names,

--- a/lib/aws-record/record/item_operations.rb
+++ b/lib/aws-record/record/item_operations.rb
@@ -553,7 +553,7 @@ module Aws
         #  include all the keys defined in model.
         # @raise [ArgumentError] if the provided keys are a duplicate.
         def find_all(keys)
-          Aws::Record::Batch.read do |db|
+          Aws::Record::Batch.read(client: dynamodb_client) do |db|
             keys.each do |key|
               db.find(self, key)
             end

--- a/spec/aws-record/record/item_operations_spec.rb
+++ b/spec/aws-record/record/item_operations_spec.rb
@@ -479,7 +479,9 @@ module Aws
         it 'passes the correct client, class and key arguments to BatchRead' do
           klass.configure_client(client: stub_client)
           mock_batch_read = double
-          expect(Batch).to receive(:read).with(client: klass.dynamodb_client).and_yield(mock_batch_read).and_return(mock_batch_read)
+          expect(Batch).to receive(:read)
+            .with(client: klass.dynamodb_client)
+            .and_yield(mock_batch_read).and_return(mock_batch_read)
           keys.each do |key|
             expect(mock_batch_read).to receive(:find).with(klass, key)
           end

--- a/spec/aws-record/record/item_operations_spec.rb
+++ b/spec/aws-record/record/item_operations_spec.rb
@@ -476,9 +476,10 @@ module Aws
           ]
         end
 
-        it 'passes the correct class and key arguments to BatchRead' do
+        it 'passes the correct client, class and key arguments to BatchRead' do
+          klass.configure_client(client: stub_client)
           mock_batch_read = double
-          expect(Batch).to receive(:read).and_yield(mock_batch_read).and_return(mock_batch_read)
+          expect(Batch).to receive(:read).with(client: klass.dynamodb_client).and_yield(mock_batch_read).and_return(mock_batch_read)
           keys.each do |key|
             expect(mock_batch_read).to receive(:find).with(klass, key)
           end


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-record-ruby/issues/148

*Description of changes:*

This PR adds support for passing the configured DynamoDB client to Batch.read operations when using the find_all method. Previously, the client configuration wasn't being passed through to batch operations.

Changes include:
- Updated `find_all` method in ItemOperations to pass the model's dynamodb_client to Batch.read
- Added corresponding test to verify client is properly passed to batch operations

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.