### PR TITLE
Dropping Ruby 2.5 and 2.6 Runtime support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,11 @@ on:
 
 jobs:
   test:
-    # change to ubuntu-latest once Ruby 2.5 and JRuby 9.2 is dropped
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.1, jruby-9.2, jruby-9.3, jruby-9.4]
+        ruby: [2.7, '3.0', 3.1, 3.2, 3.3, 3.4, jruby-9.4]
         env: [NEW_RAILS, OLD_RAILS]
 
     steps:
@@ -32,7 +31,7 @@ jobs:
 
       - name: Install     
         run: |
-          echo NEW_RAIS=$NEW_RAILS OLD_RAILS=$OLD_RAILS   
+          echo NEW_RAILS=$NEW_RAILS OLD_RAILS=$OLD_RAILS   
           bundle install --without docs     
 
       - name: Test 
@@ -42,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Ruby 3.2
+      - name: Set up Ruby 3.4
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.4
 
       - uses: actions/checkout@v2
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.7
   Exclude:
     - 'tasks/release/**/*'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Drop Ruby runtime support for 2.5 and 2.6.
+
 2.13.4 (2025-05-21)
 ------------------
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   if ENV['NEW_RAILS']
     gem 'activemodel'
   else
-    gem 'activemodel', '< 5.0'
+    gem 'activemodel', '< 7.0'
   end
 end
 

--- a/aws-record.gemspec
+++ b/aws-record.gemspec
@@ -13,8 +13,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files = Dir['lib/**/*.rb', 'LICENSE', 'CHANGELOG.md', 'VERSION']
 
-  # Require 1.85.0 for user_agent_frameworks config
-  spec.add_dependency 'aws-sdk-dynamodb', '~> 1', '>= 1.85.0'
+  spec.add_dependency 'aws-sdk-dynamodb', '~> 1', '>= 1.144.0'
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.7'
 end


### PR DESCRIPTION
Context: [AWS SDK for Ruby Deprecating Ruby 2.5 and 2.6 runtime support](https://aws.amazon.com/blogs/developer/aws-sdk-for-ruby-deprecating-ruby-2-5-2-6-runtime-supports-and-future-compatibility/)

--- 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.