### PR TITLE
Add ostruct as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Add `ostruct` as a dependency to support Ruby 3.5.
+
 2.14.0 (2025-06-04)
 ------------------
 

--- a/aws-record.gemspec
+++ b/aws-record.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files = Dir['lib/**/*.rb', 'LICENSE', 'CHANGELOG.md', 'VERSION']
 
+  spec.add_dependency 'ostruct', '~> 0'
+
   # Require 1.85.0 for user_agent_frameworks config
   spec.add_dependency 'aws-sdk-dynamodb', '~> 1', '>= 1.85.0'
 


### PR DESCRIPTION
Answers #3253

Add ostruct as a dependency because Ruby 3.5 will remove it as a bundled gem.