### PR TITLE
chore: use SPDX license identifier

### DIFF
--- a/aws-record.gemspec
+++ b/aws-record.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'AWS Record library for Amazon DynamoDB'
   spec.description   = 'Provides an object mapping abstraction for Amazon DynamoDB.'
   spec.homepage      = 'https://github.com/aws/aws-sdk-ruby-record'
-  spec.license       = 'Apache 2.0'
+  spec.license       = 'Apache-2.0'
 
   spec.require_paths = ['lib']
   spec.files = Dir['lib/**/*.rb', 'LICENSE', 'CHANGELOG.md', 'VERSION']

--- a/features/batch/step_definitions.rb
+++ b/features/batch/step_definitions.rb
@@ -54,8 +54,6 @@ Then(/^we expect the batch read result to include the following items:$/) do |st
   expect(expected.all? { |e| actual.include?(e) }).to be_truthy
 end
 
-private
-
 def remove_model_key(item)
   item.delete(:model)
   item

--- a/lib/aws-record/record/batch_read.rb
+++ b/lib/aws-record/record/batch_read.rb
@@ -37,7 +37,7 @@ module Aws
       # See {Batch.read} for example usage.
       # @return [Array] an array of unordered new items
       def execute!
-        operation_keys = unprocessed_keys[0..BATCH_GET_ITEM_LIMIT - 1]
+        operation_keys = unprocessed_keys[0..(BATCH_GET_ITEM_LIMIT - 1)]
         @unprocessed_keys = unprocessed_keys[BATCH_GET_ITEM_LIMIT..] || []
 
         operations = build_operations(operation_keys)

--- a/lib/aws-record/record/model_attributes.rb
+++ b/lib/aws-record/record/model_attributes.rb
@@ -59,7 +59,7 @@ module Aws
       end
 
       def _check_if_reserved(name)
-        return unless @model_class.instance_methods.include?(name)
+        return unless @model_class.method_defined?(name)
 
         raise Errors::ReservedName, "Cannot name an attribute #{name}, that would collide with an " \
                                     'existing instance method.'

--- a/lib/aws-record/record/table_config.rb
+++ b/lib/aws-record/record/table_config.rb
@@ -244,7 +244,7 @@ module Aws
         # we will only alter TTL status if we have a TTL attribute defined. We
         # may someday support explicit TTL deletion, but we do not yet do this.
         return unless @ttl_attribute
-        return if _ttl_compatibility_check
+        return if ttl_compatibility_check?
 
         client.update_time_to_live(
           table_name: @model_class.table_name,
@@ -268,7 +268,7 @@ module Aws
       # @return [Boolean] true if remote is compatible, false otherwise.
       def compatible?
         resp = @client.describe_table(table_name: @model_class.table_name)
-        _compatible_check(resp) && _ttl_compatibility_check
+        _compatible_check(resp) && ttl_compatibility_check?
       rescue DynamoDB::Errors::ResourceNotFoundException
         false
       end
@@ -285,14 +285,14 @@ module Aws
           _keys_equal(resp) &&
           _ad_equal(resp) &&
           _gsi_equal(resp) &&
-          _ttl_match_check
+          ttl_match_check?
       rescue DynamoDB::Errors::ResourceNotFoundException
         false
       end
 
       private
 
-      def _ttl_compatibility_check
+      def ttl_compatibility_check?
         if @ttl_attribute
           ttl_status = @client.describe_time_to_live(
             table_name: @model_class.table_name
@@ -305,7 +305,7 @@ module Aws
         end
       end
 
-      def _ttl_match_check
+      def ttl_match_check?
         ttl_status = @client.describe_time_to_live(
           table_name: @model_class.table_name
         )

--- a/lib/aws-record/record/table_migration.rb
+++ b/lib/aws-record/record/table_migration.rb
@@ -17,7 +17,7 @@ module Aws
       #  class. If this option is not included, a client will be constructed for
       #  you with default parameters.
       def initialize(model, opts = {})
-        _assert_model_valid(model)
+        valid_model?(model)
         @model = model
         @client = opts[:client] || model.dynamodb_client || Aws::DynamoDB::Client.new
         @client.config.user_agent_frameworks << 'aws-record'
@@ -130,7 +130,7 @@ module Aws
 
       private
 
-      def _assert_model_valid(model)
+      def valid_model?(model)
         _assert_required_include(model)
         model.model_valid?
       end

--- a/spec/aws-record/record/attributes_spec.rb
+++ b/spec/aws-record/record/attributes_spec.rb
@@ -15,6 +15,7 @@ module Aws
         let(:model) do
           Class.new do
             include(Aws::Record)
+
             string_attr(:id, hash_key: true)
             string_attr(:body)
           end
@@ -171,6 +172,7 @@ module Aws
           let(:klass) do
             Class.new do
               include(Aws::Record)
+
               set_table_name('TestTable')
               integer_attr(:id, hash_key: true)
               atomic_counter(:counter)
@@ -244,6 +246,7 @@ module Aws
         let(:parent_model) do
           Class.new do
             include(Aws::Record)
+
             integer_attr(:id, hash_key: true)
             date_attr(:date, range_key: true)
             list_attr(:list)
@@ -253,6 +256,7 @@ module Aws
         let(:child_model) do
           Class.new(parent_model) do
             include(Aws::Record)
+
             string_attr(:body)
           end
         end
@@ -260,6 +264,7 @@ module Aws
         let(:child_model2) do
           Class.new(parent_model) do
             include(Aws::Record)
+
             string_attr(:body2)
           end
         end

--- a/spec/aws-record/record/batch_spec.rb
+++ b/spec/aws-record/record/batch_spec.rb
@@ -10,6 +10,7 @@ describe Aws::Record::Batch do
   describe '.write' do
     Planet = Class.new do
       include(Aws::Record)
+
       integer_attr(:id, hash_key: true)
       string_attr(:name, range_key: true)
     end
@@ -87,6 +88,7 @@ describe Aws::Record::Batch do
     let(:food) do
       Class.new do
         include(Aws::Record)
+
         set_table_name('FoodTable')
         integer_attr(:id, hash_key: true, database_attribute_name: 'Food ID')
         string_attr(:dish, range_key: true)
@@ -97,6 +99,7 @@ describe Aws::Record::Batch do
     let(:breakfast) do
       Class.new(food) do
         include(Aws::Record)
+
         boolean_attr(:gluten_free)
       end
     end
@@ -104,6 +107,7 @@ describe Aws::Record::Batch do
     let(:drink) do
       Class.new do
         include(Aws::Record)
+
         set_table_name('DrinkTable')
         integer_attr(:id, hash_key: true)
         string_attr(:drink)

--- a/spec/aws-record/record/dirty_tracking_spec.rb
+++ b/spec/aws-record/record/dirty_tracking_spec.rb
@@ -194,6 +194,7 @@ describe Aws::Record::DirtyTracking do
       Class.new do
         include(ActiveModel::Model)
         include(Aws::Record)
+
         set_table_name(:test_table)
         string_attr(:mykey, hash_key: true)
         string_attr(:body)
@@ -317,6 +318,7 @@ describe Aws::Record::DirtyTracking do
         Class.new do
           include(Aws::Record)
           include(ActiveModel::Validations)
+
           set_table_name('TestTable')
           integer_attr(:id, hash_key: true)
           string_attr(:body)
@@ -335,6 +337,7 @@ describe Aws::Record::DirtyTracking do
       model = Class.new do
         include(Aws::Record)
         include(ActiveModel::Validations)
+
         set_table_name('TestTable')
         integer_attr(:id, hash_key: true)
         string_attr(:body)
@@ -424,6 +427,7 @@ describe Aws::Record::DirtyTracking do
       model = Class.new do
         include(Aws::Record)
         include(ActiveModel::Validations)
+
         set_table_name('TestTable')
         integer_attr(:id, hash_key: true)
         string_attr(:body)
@@ -480,6 +484,7 @@ describe Aws::Record::DirtyTracking do
     let(:klass) do
       Class.new do
         include(Aws::Record)
+
         set_table_name(:test_table)
         string_attr(:mykey, hash_key: true)
         string_attr(:body)
@@ -493,6 +498,7 @@ describe Aws::Record::DirtyTracking do
       let(:klass_with_defaults) do
         Class.new do
           include(Aws::Record)
+
           set_table_name(:test_table)
           string_attr(:mykey, hash_key: true)
           map_attr(:dirty_map, default_value: {})

--- a/spec/aws-record/record/item_collection_spec.rb
+++ b/spec/aws-record/record/item_collection_spec.rb
@@ -8,6 +8,7 @@ module Aws
       let(:model) do
         Class.new do
           include(Aws::Record)
+
           set_table_name('TestTable')
           integer_attr(:id, hash_key: true)
         end
@@ -206,6 +207,7 @@ module Aws
           let(:model_a) do
             Class.new do
               include(Aws::Record)
+
               set_table_name('TestTable')
               integer_attr(:id, hash_key: true)
               string_attr(:class_name)
@@ -216,6 +218,7 @@ module Aws
           let(:model_b) do
             Class.new do
               include(Aws::Record)
+
               set_table_name('TestTable')
               integer_attr(:id, hash_key: true)
               string_attr(:class_name)

--- a/spec/aws-record/record/item_operations_spec.rb
+++ b/spec/aws-record/record/item_operations_spec.rb
@@ -8,6 +8,7 @@ module Aws
       let(:klass) do
         Class.new do
           include(Aws::Record)
+
           set_table_name('TestTable')
           integer_attr(:id, hash_key: true)
           date_attr(:date, range_key: true, database_attribute_name: 'MyDate')
@@ -343,6 +344,7 @@ module Aws
           let(:klass_with_defaults) do
             Class.new do
               include(Aws::Record)
+
               set_table_name('TestTable')
               string_attr(:mykey, hash_key: true)
               map_attr(:dirty_map, default_value: {})
@@ -828,6 +830,7 @@ module Aws
           ::TEST_TABLE = Class.new do
             include(Aws::Record)
             include(ActiveModel::Validations)
+
             set_table_name('TestTable')
             integer_attr(:id, hash_key: true)
             date_attr(:date, range_key: true)

--- a/spec/aws-record/record/query_spec.rb
+++ b/spec/aws-record/record/query_spec.rb
@@ -8,6 +8,7 @@ module Aws
       let(:klass) do
         Class.new do
           include(Aws::Record)
+
           set_table_name('TestTable')
           integer_attr(:id, hash_key: true)
           date_attr(:date, range_key: true)

--- a/spec/aws-record/record/secondary_indexes_spec.rb
+++ b/spec/aws-record/record/secondary_indexes_spec.rb
@@ -8,6 +8,7 @@ module Aws
       let(:klass) do
         Class.new do
           include(Aws::Record)
+
           set_table_name('TestTable')
           integer_attr(:forum_id, hash_key: true)
           integer_attr(:post_id, range_key: true)
@@ -161,6 +162,7 @@ module Aws
       let(:parent_model) do
         Class.new do
           include(Aws::Record)
+
           integer_attr(:id, hash_key: true)
           string_attr(:name, range_key: true)
           string_attr(:message)
@@ -170,6 +172,7 @@ module Aws
       let(:child_model) do
         Class.new(parent_model) do
           include(Aws::Record)
+
           string_attr(:foo)
           string_attr(:bar)
         end

--- a/spec/aws-record/record/table_migration_spec.rb
+++ b/spec/aws-record/record/table_migration_spec.rb
@@ -37,6 +37,7 @@ module Aws
         let(:model) do
           model = Class.new do
             include(Aws::Record)
+
             set_table_name('TestTable')
             integer_attr(:id, hash_key: true)
           end
@@ -57,6 +58,7 @@ module Aws
         let(:klass) do
           Class.new do
             include(Aws::Record)
+
             set_table_name('TestTable')
             integer_attr(:id, hash_key: true)
             date_attr(:date, range_key: true, database_attribute_name: 'datekey')

--- a/spec/aws-record/record/transactions_spec.rb
+++ b/spec/aws-record/record/transactions_spec.rb
@@ -12,6 +12,7 @@ module Aws
       let(:table_one) do
         Class.new do
           include(Aws::Record)
+
           set_table_name('TableOne')
           integer_attr(:id, hash_key: true)
           string_attr(:range, range_key: true)
@@ -23,6 +24,7 @@ module Aws
       let(:table_two) do
         Class.new do
           include(Aws::Record)
+
           set_table_name('TableTwo')
           string_attr(:uuid, hash_key: true)
           string_attr(:body)

--- a/spec/aws-record/record_spec.rb
+++ b/spec/aws-record/record_spec.rb
@@ -28,6 +28,7 @@ module Aws
         expected = 'ExpectedTableName'
         ::UnitTestModelTwo = Class.new do
           include(Aws::Record)
+
           set_table_name(expected)
         end
         expect(::UnitTestModelTwo.table_name).to eq(expected)
@@ -48,6 +49,7 @@ module Aws
       let(:model) do
         Class.new do
           include(Aws::Record)
+
           set_table_name('TestTable')
         end
       end
@@ -84,6 +86,7 @@ module Aws
       let(:model) do
         Class.new do
           include(Aws::Record)
+
           set_table_name('TestTable')
         end
       end
@@ -111,6 +114,7 @@ module Aws
       let(:model) do
         Class.new do
           include(Aws::Record)
+
           set_table_name('TestTable')
           string_attr(:uuid, hash_key: true)
           attr(:mt, Aws::Record::Marshalers::StringMarshaler.new)
@@ -131,6 +135,7 @@ module Aws
       let(:model) do
         Class.new do
           include(Aws::Record)
+
           set_table_name('TestTable')
           string_attr(:uuid, hash_key: true)
           map_attr(:things, default_value: {})
@@ -147,6 +152,7 @@ module Aws
       let(:model) do
         Class.new do
           include(Aws::Record)
+
           set_table_name('TestTable')
           string_attr(:uuid, hash_key: true)
           string_attr(:other_attr)
@@ -170,6 +176,7 @@ module Aws
       let(:parent_model) do
         Class.new do
           include(Aws::Record)
+
           set_table_name('ParentTable')
         end
       end
@@ -208,6 +215,7 @@ module Aws
       let(:parent_model) do
         Class.new do
           include(Aws::Record)
+
           integer_attr(:id, hash_key: true)
         end
       end
@@ -215,6 +223,7 @@ module Aws
       let(:child_model) do
         Class.new(parent_model) do
           include(Aws::Record)
+
           string_attr(:foo)
         end
       end


### PR DESCRIPTION
The [gemspec specification](https://guides.rubygems.org/specification-reference/#method-i-license-3D) , mentions that 

> The simplest way is to specify the standard SPDX ID spdx.org/licenses/ for the license.

And in fact most gems adheres to this convention, including some others AWS gems, like [aws-sdk-s3](https://github.com/aws/aws-sdk-ruby/blob/aa020cd8c3d09be074cc2b018691f0145be5802a/gems/aws-sdk-s3/aws-sdk-s3.gemspec#L18) and all the gems in that repo.

Based on https://spdx.org/licenses/Apache-2.0.html the identifier is `Apache-2.0`.